### PR TITLE
Add SummarizeSpec.py and update README and docs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,51 +1,126 @@
-This repository contains tooks tools ksl has or is developing for anaylyzing LVM data or for develping S/W for better sky subtraction.
+This repository contains tools ksl has or is developing for analyzing LVM data or for developing S/W for better sky subtraction.
 
-Some are intended for scince and others are intended to aide in the development of better sky subtraction procecures
+Some are intended for science and others are intended to aide in the development of better sky subtraction procedures.
 
 To use the various routines that are in this repository, one should add
-this directory to your PYTHONPATH and PATH
+this directory to your PYTHONPATH and PATH.
 
-Most of the programs in this directory accept -h options to inindicate
-what they do, and the various options associated with them
+Most of the programs in this directory accept -h options to indicate
+what they do, and the various options associated with them.
 
-To have a good coneption of the overall concept, one should understand that a data reduction pipeline exists for LVM, which one can run on the raw science exposures after downloading the raw scince data.  The data reduction pipepline expects a well-defined, but compliated directory structure. The data reduction pipeline produces flux-calibrated row-stacked spectra of each exposure with names like lvmCFrame-00009240.fits which contain the row stacked flux-calibrated spectra, where 9240 is the exposure number.  
+To have a good conception of the overall concept, one should understand that a data reduction pipeline exists for LVM, which one can run on the raw science exposures after downloading the raw science data.  The data reduction pipeline expects a well-defined, but complicated directory structure. The data reduction pipeline produces flux-calibrated row-stacked spectra of each exposure with names like lvmCFrame-00009240.fits which contain the row stacked flux-calibrated spectra, where 9240 is the exposure number.
 
-For doing, science, the current versions of the row-stacked spectra are lacking information about where the various fibers are positioned on the sky.  To address this problem, ksl has written S/W to obtain this information, the quality of which depends somewhat on how much ancilary information is available about each exposure, and in particular whether the data from the guide star camera exists.  If it does, it can be used to update information abut the pointing positions from those that were desired; if not the desired postions are the only information that is available.
+For doing science, the current versions of the row-stacked spectra are lacking information about where the various fibers are positioned on the sky.  To address this problem, ksl has written S/W to obtain this information, the quality of which depends somewhat on how much ancillary information is available about each exposure, and in particular whether the data from the guide star camera exists.  If it does, it can be used to update information about the pointing positions from those that were desired; if not the desired positions are the only information that is available.
 
-To obtain the best information available currently, ksl has written a subsidiary routine xcal.py, which (a) if one has a local version of the lvmdrp instaled, and (b) which one has used to process the data with the lvmdrp, then it adds information about the pointing positions (and for purpose of sky subraction information about the moon) to a modified version of the calibrated RSS spectra.  This produces a file with names like  XCFrame-00009240.fits, which are intended for further analysis.  
+To obtain the best information available currently, ksl has written a subsidiary routine xcal.py, which (a) if one has a local version of the lvmdrp installed, and (b) which one has used to process the data with the lvmdrp, then it adds information about the pointing positions (and for the purpose of sky subtraction information about the moon) to a modified version of the calibrated RSS spectra.  This produces a file with names like XCFrame-00009240.fits, which are intended for further analysis.
 
-Here is a brief description of each program:
+## Quick Start
 
-* kslmap.py creates 'images" of an exposure from either the lvm drp created reduced data or the xcal data. 
+### Requirements
 
-* PlotClosest.py creates an ansci table for the fiber closest to a given ra and dec.  It can run on either the direct output of xcal.py or on the direct output of the lvmdrp.  
+- Python 3.8 or later
+- [numpy](https://numpy.org/), [scipy](https://scipy.org/), [astropy](https://www.astropy.org/), [matplotlib](https://matplotlib.org/)
 
-The remaining programs are mainly intended for use when one has a local version of the LVM DRP installed, or for work on sky subtraction
+Optional, for full functionality:
+- **lvmdrp** — LVM Data Reduction Pipeline (needed for `Reduce.py` and local reprocessing)
+- **sdss_access** — for retrieving data directly from the Utah archive
+- **skycorr** — ESO sky-subtraction tool (needed for `RunSkyCorr.py`)
 
-* Reduce.py downlaods data from Utah and processes it with the quick-reduction version of the LVM drp.
+### Installation
 
-* LocateData.py is intended to find a lvmCFrame file locally or in the file structure that is part of LVMDRP.  If multiple versions of a file exist, it returns the name of
-the last one created.  
+Clone the repository:
 
-* PrepSkyCorr.py creates data in a format that can be used by SkyCorr, specificaly, it creates 3 different fits files for the science, SkyE and SkyW telescopes
+```bash
+git clone https://github.com/kslong/lvm_ksl.git
+cd lvm_ksl
+```
 
-* RunSkyCorr.py allows one to run SkyCoor on calibrated data.  The routine creates the .par files that SkyCorr needs and then runs SkyCorr on the Prepped files.
+Add `py_progs` to your shell environment so Python can import the modules
+and the scripts can be run directly from the command line:
 
-* SkySub.py allows one to run a simple sky subtraction (separating the continuum from the sky lines, and rescaling the sky lines to minimize the differences between the science and sky spectrum.  This uses the same input files as SkyCorr.
+**bash / zsh** — add to `~/.bashrc` or `~/.zshrc`:
+```bash
+export PYTHONPATH="/path/to/lvm_ksl/py_progs:$PYTHONPATH"
+export PATH="/path/to/lvm_ksl/py_progs:$PATH"
+```
 
-* SummarizeData.py - Summarizes the raw data that has been dowwnloaded.  Used on the Utah cluster one can make a summary of all of the data that has been obtained
+**csh / tcsh** — add to `~/.cshrc`:
+```csh
+setenv PYTHONPATH /path/to/lvm_ksl/py_progs:$PYTHONPATH
+setenv PATH /path/to/lvm_ksl/py_progs:$PATH
+```
 
-* SkyID.py is intended to identify what SkyFields are associated with what pointings.  It uses the output of SummarizeData.py.
+Replace `/path/to/lvm_ksl` with the directory where you cloned the repository.
 
-* CleanAncillary.py - removes the ancillary data files that have been created by processing (which can take space if one is not intereted in them)
+### Verifying the installation
 
+Most scripts accept `-h` to print usage information:
 
-The repository will likely contain other routines as time goes forward.  Hopefully, they will be docuemnted, but usually there is at least some indication of what they do in the headers information at the top of the routines.
+```bash
+GetFromUtah.py -h
+rss_snap.py -h
+```
 
-Some modeules are obsolete; these should have been moved to the deprecated subdirectory
+### Documentation
 
-* xcal.py adds the ra and decs for individual fibers in a calibrated exposure. It also adds information needed to create a WCS that is used by kslmap to create an image of an RSS file with good astrometry. The LVM DRP (data analysis pipelines) creates files with names like lvmCFrame-00009240.fits which contain the row stacked flux-calibrated spectra, where 9240 is the exposure number. xcal.py files will have names like XCFrame-00009240.fits
+Full documentation is built with Sphinx:
 
+```bash
+pip install sphinx sphinx-rtd-theme sphinx-autoapi
+cd /path/to/lvm_ksl/docs
+make html
+```
 
-* fib2radec.py creates an astropy table giving the RA and Dec of each fibeer in a calbirated LVM imaage; if the guide star data are avalible the program will use information from that ,but if not it will use data in the calbrated file to determin the ra's and dec's of each fiber.
+Open `docs/html/index.html` in a browser.  The documentation covers all
+major workflows including data retrieval, sky subtraction, spectral
+analysis, and the Magellanic Cloud SNR analysis pipeline.
 
+---
+
+## Overview
+
+The repository contains around 60 independent Python scripts in `py_progs/`,
+organised around the following workflows.  Full documentation for each is
+in the Sphinx docs (see above).
+
+**Locating observations** — cross-match a source catalog against the LVM
+drpall file to find which exposures cover each target and how much
+integration time has accumulated (`find_obs.py`).
+
+**Data retrieval and reduction** — retrieve reduced data from the Utah
+archive or run the LVM DRP locally, and locate processed files on disk
+(`GetFromUtah.py`, `Reduce.py`, `LocateData.py`, `LocateReduced.py`).
+
+**Summarizing data** — create compact spectral summaries across many
+exposures for quality evaluation, broken down by ring position or by
+spectrograph (`SummarizeData.py`, `SummarizeCframe.py`,
+`SummarizeSframe.py`, `SummarizeRings.py`, `SummarizeSpec.py`).
+
+**Sky subtraction** — prepare inputs, run SkyCorr, and evaluate sky
+subtraction residuals (`Prep4SkyCorr.py`, `RunSkyCorr.py`, `SkySub.py`,
+`eval_sky.py`).
+
+**Spectral analysis** — extract spectra, fit Gaussian emission-line
+profiles, and measure fluxes (`GetSpec.py`, `GetRegSpec.py`,
+`lvm_gaussfit.py`, `lvm_flux.py`).
+
+**Visualization** — produce line maps, broadband images, and spectral
+overview plots (`kslmap.py`, `line_map.py`, `quick_map.py`, `PlotSpec.py`,
+`PlotSpec3.py`, `SNRPlot.py`).
+
+**RSS combining** — combine multiple dithered SFrame exposures into a
+single row-stacked spectrum on a regular or original fiber grid
+(`rss_combine.py`, `rss_snap.py`).
+
+**Region files and background subtraction** — define source and
+background regions, generate annular backgrounds, and extract
+background-subtracted spectra (`MakeLVMReg.py`,
+`GenAnnularBackground.py`).
+
+**End-to-end science workflow** — a documented pipeline for analysing
+Magellanic Cloud SNRs from exposure identification through emission-line
+fitting is described in full in the Sphinx documentation.
+
+Scripts not yet covered by detailed documentation still include a usage
+summary in their module docstring; run any script with `-h` to see it.
+Obsolete scripts have been moved to the `deprecated/` subdirectory.

--- a/docs/source/api/SummarizeSpec/index.rst
+++ b/docs/source/api/SummarizeSpec/index.rst
@@ -1,0 +1,263 @@
+SummarizeSpec
+=============
+
+.. py:module:: SummarizeSpec
+
+.. autoapi-nested-parse::
+
+                       Space Telescope Science Institute
+
+   Synopsis:
+
+   Create a summary of CFrame (flux-calibrated, before sky subtraction) data
+   where each row contains the percentile spectrum for each of the three LVM
+   spectrographs from a single exposure.  Useful for evaluating
+   spectrograph-to-spectrograph variations before and after sky subtraction.
+
+   Command line usage::
+
+       SummarizeSpec.py [-h] [-sf] [-ver drp_ver] [-percent 50] [-emin 900]
+                        [-out name] exp_start exp_stop delta
+
+   Description:
+
+   This script processes multiple CFrame files (the default) and computes the
+   percentile spectrum for science fibers belonging to each of the three LVM
+   spectrographs (spectrographid = 1, 2, 3) as recorded in the SLITMAP
+   extension.  Only fibers with telescope == 'Sci' and fibstatus == 0 are
+   included.  The -sf switch causes SFrame files to be read instead.
+
+   File paths are taken from the location column of the drpall file, which
+   records SFrame paths.  For CFrame files the path is adjusted automatically
+   by replacing 'SFrame' with 'CFrame' in the location string.
+
+   An exposure is included in the output only if science fibers are found
+   for all three spectrographs.  Exposures where one or more spectrographs
+   are missing are skipped and recorded in a separate ASCII table.
+
+   Two output files are produced.  The main FITS file contains one row per
+   valid exposure in each flux extension.  The skipped-exposure table lists
+   every exposure that was rejected, with columns indicating which
+   spectrographs were present and which were absent.
+
+   Options: -h prints this documentation; -sf reads SFrame instead of CFrame
+   files; -ver drp_ver sets the DRP version (default 1.2.0); -percent N sets
+   the percentile to compute (default 50 = median); -emin N sets the minimum
+   exposure time in seconds to include (default 900); -out name sets the root
+   name of the output files.
+
+   Positional arguments: exp_start is the first exposure number to consider;
+   exp_stop is the last exposure number; delta processes every Nth exposure.
+
+   Primary routines:
+
+       doit
+
+   Notes:
+
+   The three flux extensions are named FLUX1, FLUX2, and FLUX3, corresponding
+   to spectrographid values 1, 2, and 3 respectively.  Each is a 2-D array
+   with one row per valid exposure and one column per wavelength pixel.
+
+   The skipped-exposure table is always written, even if no exposures were
+   skipped, so there is always a record that the completeness check was
+   performed.
+
+   History:
+
+   260312 ksl Coding begun, based on SummarizeRings.py
+
+
+
+Attributes
+----------
+
+.. autoapisummary::
+
+   SummarizeSpec.XMUSKIE
+   SummarizeSpec.XRAINBOW
+   SummarizeSpec.XTOP
+
+
+Functions
+---------
+
+.. autoapisummary::
+
+   SummarizeSpec.augment_drp_all
+   SummarizeSpec.doit
+   SummarizeSpec.find_top
+   SummarizeSpec.get_all_spec_specs
+   SummarizeSpec.get_spec
+   SummarizeSpec.make_spec_specs
+   SummarizeSpec.read_drpall
+   SummarizeSpec.select
+   SummarizeSpec.steer
+
+
+Module Contents
+---------------
+
+.. py:data:: XMUSKIE
+   :value: '/home/long/Projects/lvm_data/sas'
+
+
+.. py:data:: XRAINBOW
+   :value: '/Users/long/Projects/lvm_data/sas'
+
+
+.. py:data:: XTOP
+   :value: '/uufs/chpc.utah.edu/common/home/sdss51/'
+
+
+.. py:function:: augment_drp_all(xtab)
+
+   Add survey classification, near/far sky telescope, and redshift columns
+   to a drpall table.
+
+   Parameters:
+       xtab (astropy.table.Table): drpall table with sci_ra, sci_dec, skye_ra, skye_dec, skyw_ra, skyw_dec columns.
+
+   Returns:
+       astropy.table.Table: Input table with Survey, Near, Far, and
+       Redshift columns added.
+
+
+.. py:function:: doit(exp_start=4000, exp_stop=8000, delta=5, exp_min=900.0, out_name='', drp_ver='1.2.0', percentile=50, file_type='CFrame')
+
+   Top-level driver: read drpall, select exposures, compute spectrograph spectra.
+
+   Parameters:
+       exp_start (int): First exposure number to process.
+       exp_stop (int): Last exposure number to process.
+       delta (int): Process every Nth exposure.
+       exp_min (float): Minimum exposure time in seconds.
+       out_name (str): Output file root name.
+       drp_ver (str): DRP version string.
+       percentile (int): Percentile to compute across fibers.
+       file_type (str): 'CFrame' (default) or 'SFrame'.
+
+   Returns:
+       None
+
+
+.. py:function:: find_top()
+
+   Determine the top-level data directory for the current machine.
+
+   Returns:
+       str: Path to the top-level data directory, or an empty string
+       if the location cannot be determined.
+
+
+.. py:function:: get_all_spec_specs(filename, percentile=50)
+
+   Compute percentile flux spectra for each spectrograph from one SFrame file.
+
+   Opens the SFrame FITS file and checks whether science fibers are
+   present for each of the three spectrographs (spectrographid 1, 2, 3).
+   If any spectrograph has no valid science fibers the function returns
+   None for all arrays together with a status dictionary that records
+   which spectrographs were found.
+
+   Parameters:
+       filename (str): Path to the SFrame FITS file.
+       percentile (int): Percentile to compute across fibers (default 50).
+
+   Returns:
+       tuple: (wav, flux1, flux2, flux3, status) where wav is the
+       wavelength array, flux1/flux2/flux3 are 1-D percentile spectra
+       for spectrographs 1/2/3, and status is a dict with keys 'SP1',
+       'SP2', 'SP3' set to True if fibers were found and False otherwise.
+       If the file cannot be opened, returns (None, None, None, None, None).
+       If any spectrograph is missing, returns (None, None, None, None, status).
+
+
+.. py:function:: get_spec(xtab, spectrograph_id)
+
+   Select good science fibers for a given spectrograph from a SLITMAP table.
+
+   Filters to rows where telescope == 'Sci', fibstatus == 0, and
+   spectrographid == spectrograph_id.
+
+   Parameters:
+       xtab (astropy.table.Table): SLITMAP table from an SFrame file.
+       spectrograph_id (int): Spectrograph identifier (1, 2, or 3).
+
+   Returns:
+       astropy.table.Table: Filtered table of matching fibers.
+
+
+.. py:function:: make_spec_specs(xtab, data_dir, outfile='', percentile=50, file_type='CFrame')
+
+   Process multiple CFrame or SFrame files and write a FITS summary by spectrograph.
+
+   Iterates over the exposures in xtab, calling get_all_spec_specs for
+   each file that exists on disk.  Exposures for which not all three
+   spectrographs have valid science fibers are skipped and recorded in a
+   separate ASCII table written alongside the main output file.
+
+   The drpall location column records SFrame paths.  When file_type is
+   'CFrame' (the default), 'SFrame' is replaced with 'CFrame' in the path
+   before checking for the file.
+
+   The main FITS file contains extensions WAVE, FLUX1, FLUX2, FLUX3, and
+   drp_all.  FLUX1/FLUX2/FLUX3 are 2-D arrays (n_exposures x n_wavelengths)
+   containing the percentile spectrum for spectrographs 1, 2, and 3.
+
+   The skipped-exposure table is always written and contains one row per
+   rejected exposure with columns expnum, mjd, tileid, SP1, SP2, SP3
+   showing which spectrographs were present (True) or absent (False).
+
+   Parameters:
+       xtab (astropy.table.Table): drpall table of selected exposures.
+       data_dir (str): Top-level data directory prepended to the location column of xtab to form full file paths.
+       outfile (str): Output filename root (default 'test_spec.fits').
+       percentile (int): Percentile to compute across fibers (default 50).
+       file_type (str): 'CFrame' (default) or 'SFrame'.
+
+   Returns:
+       None
+
+
+.. py:function:: read_drpall(drp_ver='1.2.0')
+
+   Read the drpall FITS file and return an augmented metadata table.
+
+   Looks for the file locally first, then falls back to the Utah path.
+
+   Parameters:
+       drp_ver (str): DRP version string (default '1.2.0').
+
+   Returns:
+       astropy.table.Table: drpall table with survey classification
+       columns added, or an empty list if the file cannot be found
+       or read.
+
+
+.. py:function:: select(ztab, exp_start=4000, exp_stop=8000, delta=5, exp_min=900.0)
+
+   Select every Nth exposure between exp_start and exp_stop.
+
+   Parameters:
+       ztab (astropy.table.Table): drpall table.
+       exp_start (int): First exposure number to include.
+       exp_stop (int): Last exposure number to include.
+       delta (int): Step size; selects every Nth row.
+       exp_min (float): Minimum exposure time in seconds.
+
+   Returns:
+       astropy.table.Table: Filtered table.
+
+
+.. py:function:: steer(argv)
+
+   Parse command line arguments and run the spectrograph summary.
+
+   Parameters:
+       argv (list): Command line argument list (typically sys.argv).
+
+   Returns:
+       None
+
+

--- a/docs/source/api/find_obs/index.rst
+++ b/docs/source/api/find_obs/index.rst
@@ -118,19 +118,12 @@ Module Contents
    avoid clashes before the two tables are horizontally stacked.
 
    Parameters:
-       source_file (str): Path to the ASCII source catalog.  Must
-           contain columns ``RA`` (degrees), ``Dec`` (degrees), and
-           ``Source_name``.
-       obs (astropy.table.Table): Observation table from
-           ``load_observations``.
+       source_file (str): Path to the ASCII source catalog with RA, Dec, and Source_name columns.
+       obs (astropy.table.Table): Observation table from ``load_observations``.
        max_sep_arcsec (float): Cross-match radius in arcseconds.
 
    Returns:
-       astropy.table.Table: Matched table with one row per
-       observation-source pair.  Includes all columns from both
-       the source catalog and the observation table, plus a
-       ``separation`` column in arcseconds.  Returns an empty
-       Table if no matches are found.
+       astropy.table.Table: Matched table with one row per observation-source pair, including all columns from both the source catalog and the observation table plus a ``separation`` column in arcseconds.  Returns an empty Table if no matches are found.
 
 
 .. py:function:: load_observations(drpall_file)
@@ -179,9 +172,7 @@ Module Contents
    the source and the matched pointing centres.
 
    Parameters:
-       matches (astropy.table.Table): Matched pair table returned by
-           ``find_matches``.  Must contain columns ``Source_name``,
-           ``exptime``, and ``separation``.
+       matches (astropy.table.Table): Matched pair table returned by ``find_matches`` with columns ``Source_name``, ``exptime``, and ``separation``.
 
    Returns:
        astropy.table.Table: Summary table with columns ``Source_name``,

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -1,0 +1,75 @@
+API Reference
+=============
+
+This page contains auto-generated API reference documentation [#f1]_.
+
+.. toctree::
+   :titlesonly:
+
+   /api/big_combine/index
+   /api/check4unicode_filenames/index
+   /api/check4unicode_txt/index
+   /api/CheckData/index
+   /api/CheckReduced/index
+   /api/CleanAncillary/index
+   /api/DAP2tab/index
+   /api/DAPGauss2tab/index
+   /api/eval_sky/index
+   /api/eval_standard/index
+   /api/fib2radec/index
+   /api/find_obs/index
+   /api/FitsInfo/index
+   /api/GenAnnularBackground/index
+   /api/GetDAP/index
+   /api/GetFromUtah/index
+   /api/GetRegSpec/index
+   /api/GetSimple/index
+   /api/GetSolar/index
+   /api/GetSpec/index
+   /api/kslmap/index
+   /api/line_map/index
+   /api/LocateData/index
+   /api/LocateReduced/index
+   /api/LSnap/index
+   /api/lvm_double/index
+   /api/lvm_flux/index
+   /api/lvm_gaussfit/index
+   /api/lvm_triple/index
+   /api/MakeLVMReg/index
+   /api/MakeVideo/index
+   /api/peaks/index
+   /api/PlotSpec/index
+   /api/PlotSpec3/index
+   /api/Prep4SkyCorr/index
+   /api/quick_map/index
+   /api/QuickLook/index
+   /api/Reduce/index
+   /api/rename_unicode_filenames/index
+   /api/rss2image/index
+   /api/rss_combine/index
+   /api/rss_combine_pos/index
+   /api/rss_explore/index
+   /api/rss_snap/index
+   /api/RunSky/index
+   /api/RunSkyCalcAltAz/index
+   /api/RunSkyCorr/index
+   /api/sky_gaussfit/index
+   /api/sky_plot/index
+   /api/SkyCalcObs/index
+   /api/SkyID/index
+   /api/SkyModelObs/index
+   /api/SkySub/index
+   /api/SNRPlot/index
+   /api/SumCframe/index
+   /api/SummarizeCframe/index
+   /api/SummarizeData/index
+   /api/SummarizeRings/index
+   /api/SummarizeSframe/index
+   /api/SummarizeSpec/index
+   /api/unicode2ascii/index
+   /api/w28_gaussfit/index
+   /api/xhtml/index
+   /api/xSummarizeData/index
+   /api/zSummarizeData/index
+
+.. [#f1] Created with `sphinx-autoapi <https://github.com/readthedocs/sphinx-autoapi>`_

--- a/docs/source/summarize.rst
+++ b/docs/source/summarize.rst
@@ -9,13 +9,14 @@ at different stages of processing. These scripts are useful for:
 - Comparing sky levels and sky subtraction residuals over time
 - Identifying trends or problems in the data
 
-Four summarization scripts are provided, each operating on different
+Five summarization scripts are provided, each operating on different
 data products:
 
 - ``SummarizeData.py`` - Catalog raw/unprocessed data files
 - ``SummarizeCframe.py`` - Summarize CFrame spectra (before sky subtraction)
 - ``SummarizeSframe.py`` - Summarize SFrame spectra (after sky subtraction)
 - ``SummarizeRings.py`` - Summarize SFrame spectra by fiber ring position
+- ``SummarizeSpec.py`` - Summarize CFrame or SFrame spectra by spectrograph
 
 
 SummarizeData.py - Cataloging Raw Data
@@ -234,6 +235,96 @@ A FITS file with one row per exposure, containing:
 - Diagnosing fiber-dependent calibration issues
 
 
+SummarizeSpec.py - Per-Spectrograph Spectral Summary
+-----------------------------------------------------
+
+This script processes CFrame files (the default) or SFrame files and
+computes the percentile spectrum separately for the science fibers
+belonging to each of the three LVM spectrographs.  Only fibers with
+``telescope == 'Sci'`` and ``fibstatus == 0`` are used, and the
+spectrograph is identified from the ``spectrographid`` column of the
+SLITMAP extension.
+
+An exposure is included in the output only if all three spectrographs
+have valid science fibers.  Exposures missing one or more spectrographs
+are skipped and recorded in a companion ASCII table.
+
+**Command line usage**::
+
+    SummarizeSpec.py [-sf] [-ver drp_ver] [-percent 50] [-emin 900] [-out name]
+                     exp_start exp_stop delta
+
+**Options:**
+
+-h
+    Print help and exit.
+
+-sf
+    Read SFrame (sky-subtracted) files instead of the default CFrame
+    (flux-calibrated, before sky subtraction) files.
+
+-ver drp_ver
+    DRP version to use (default: 1.2.0).
+
+-percent N
+    Percentile to compute across fibers (default: 50 = median).
+
+-emin N
+    Minimum exposure time in seconds to include (default: 900).
+
+-out name
+    Output filename root.  If omitted, a name is generated automatically
+    from the file type, DRP version, and exposure range.
+
+**Arguments:**
+
+exp_start
+    Starting exposure number.
+
+exp_stop
+    Ending exposure number.
+
+delta
+    Process every Nth exposure (use 1 for all).
+
+**Output files:**
+
+A FITS file with the following extensions:
+
+=========  =============  =====================================================
+Extension  Type           Contents
+=========  =============  =====================================================
+PRIMARY    ImageHDU       No data; header records PERCENT, SP1/SP2/SP3, Title
+WAVE       ImageHDU       1-D wavelength array
+FLUX1      ImageHDU       2-D array (n_exposures × n_wavelengths), spectrograph 1
+FLUX2      ImageHDU       2-D array (n_exposures × n_wavelengths), spectrograph 2
+FLUX3      ImageHDU       2-D array (n_exposures × n_wavelengths), spectrograph 3
+drp_all    BinTableHDU    drpall metadata for the accepted exposures only
+=========  =============  =====================================================
+
+A fixed-width ASCII table ``<out>.skipped.txt`` is also always written,
+listing every rejected exposure with columns ``expnum``, ``mjd``,
+``tileid``, ``SP1``, ``SP2``, ``SP3`` (``True`` = present, ``False`` =
+absent).  This file is written even if no exposures were skipped, providing
+a record that the completeness check was performed.
+
+**Notes:**
+
+The drpall ``location`` column records SFrame paths.  For CFrame files the
+script replaces ``'SFrame'`` with ``'CFrame'`` in the path automatically.
+The output filename includes the file type (e.g.
+``XSpec_CFrame_1.2.0_10000_20000_10_50.fits``) so that CFrame and SFrame
+runs do not overwrite each other.
+
+**Use cases:**
+
+- Detecting spectrograph-to-spectrograph offsets in flux calibration
+- Identifying whether sky subtraction residuals are confined to one
+  spectrograph
+- Comparing CFrame and SFrame runs to isolate sky subtraction artefacts
+  by spectrograph
+
+
 Typical Workflow
 ----------------
 
@@ -259,6 +350,14 @@ A typical workflow for evaluating data quality might be:
 
        SummarizeRings.py -out rings_summary 10000 20000 10
 
+5. **Check for spectrograph-to-spectrograph variations**::
+
+       SummarizeSpec.py -out spec_summary 10000 20000 10
+
+   Add ``-sf`` to compare the same exposures after sky subtraction::
+
+       SummarizeSpec.py -sf -out spec_summary_sf 10000 20000 10
+
 
 See Also
 --------
@@ -267,3 +366,4 @@ See Also
 - :doc:`api/SummarizeCframe/index` - API documentation
 - :doc:`api/SummarizeSframe/index` - API documentation
 - :doc:`api/SummarizeRings/index` - API documentation
+- :doc:`api/SummarizeSpec/index` - API documentation

--- a/py_progs/SummarizeSpec.py
+++ b/py_progs/SummarizeSpec.py
@@ -1,0 +1,549 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+'''
+                    Space Telescope Science Institute
+
+Synopsis:
+
+Create a summary of CFrame (flux-calibrated, before sky subtraction) data
+where each row contains the percentile spectrum for each of the three LVM
+spectrographs from a single exposure.  Useful for evaluating
+spectrograph-to-spectrograph variations before and after sky subtraction.
+
+Command line usage::
+
+    SummarizeSpec.py [-h] [-sf] [-ver drp_ver] [-percent 50] [-emin 900]
+                     [-out name] exp_start exp_stop delta
+
+Description:
+
+This script processes multiple CFrame files (the default) and computes the
+percentile spectrum for science fibers belonging to each of the three LVM
+spectrographs (spectrographid = 1, 2, 3) as recorded in the SLITMAP
+extension.  Only fibers with telescope == 'Sci' and fibstatus == 0 are
+included.  The -sf switch causes SFrame files to be read instead.
+
+File paths are taken from the location column of the drpall file, which
+records SFrame paths.  For CFrame files the path is adjusted automatically
+by replacing 'SFrame' with 'CFrame' in the location string.
+
+An exposure is included in the output only if science fibers are found
+for all three spectrographs.  Exposures where one or more spectrographs
+are missing are skipped and recorded in a separate ASCII table.
+
+Two output files are produced.  The main FITS file contains one row per
+valid exposure in each flux extension.  The skipped-exposure table lists
+every exposure that was rejected, with columns indicating which
+spectrographs were present and which were absent.
+
+Options: -h prints this documentation; -sf reads SFrame instead of CFrame
+files; -ver drp_ver sets the DRP version (default 1.2.0); -percent N sets
+the percentile to compute (default 50 = median); -emin N sets the minimum
+exposure time in seconds to include (default 900); -out name sets the root
+name of the output files.
+
+Positional arguments: exp_start is the first exposure number to consider;
+exp_stop is the last exposure number; delta processes every Nth exposure.
+
+Primary routines:
+
+    doit
+
+Notes:
+
+The three flux extensions are named FLUX1, FLUX2, and FLUX3, corresponding
+to spectrographid values 1, 2, and 3 respectively.  Each is a 2-D array
+with one row per valid exposure and one column per wavelength pixel.
+
+The skipped-exposure table is always written, even if no exposures were
+skipped, so there is always a record that the completeness check was
+performed.
+
+History:
+
+260312 ksl Coding begun, based on SummarizeRings.py
+
+'''
+
+import sys
+import os
+import numpy as np
+from astropy.io import ascii, fits
+from astropy.table import Table
+from astropy.wcs import WCS
+from astropy.coordinates import SkyCoord
+import astropy.units as u
+
+
+def augment_drp_all(xtab):
+    '''
+    Add survey classification, near/far sky telescope, and redshift columns
+    to a drpall table.
+
+    Parameters:
+        xtab (astropy.table.Table): drpall table with sci_ra, sci_dec,
+            skye_ra, skye_dec, skyw_ra, skyw_dec columns.
+
+    Returns:
+        astropy.table.Table: Input table with Survey, Near, Far, and
+        Redshift columns added.
+    '''
+    drp_all = xtab
+    sci_ra = drp_all['sci_ra']
+    sci_dec = drp_all['sci_dec']
+    skye_ra = drp_all['skye_ra']
+    skye_dec = drp_all['skye_dec']
+    skyw_ra = drp_all['skyw_ra']
+    skyw_dec = drp_all['skyw_dec']
+
+    sci_coord = SkyCoord(ra=sci_ra * u.degree, dec=sci_dec * u.degree, frame='icrs')
+    skye_coord = SkyCoord(ra=skye_ra * u.degree, dec=skye_dec * u.degree, frame='icrs')
+    skyw_coord = SkyCoord(ra=skyw_ra * u.degree, dec=skyw_dec * u.degree, frame='icrs')
+    de = sci_coord.separation(skye_coord).degree
+    dw = sci_coord.separation(skyw_coord).degree
+    galactic_lat = sci_coord.galactic.b.degree
+
+    lmc_pos = SkyCoord(ra=80.89416666666668 * u.degree, dec=-69.75618 * u.degree, frame='icrs')
+    lmc_sep = lmc_pos.separation(sci_coord).degree
+    smc_pos = SkyCoord(ra=13.1875 * u.degree, dec=-72.8286 * u.degree, frame='icrs')
+    smc_sep = smc_pos.separation(sci_coord).degree
+
+    xlocal = np.select([np.fabs(galactic_lat) > 10], ['HighLat'], default='Plane')
+    xlocal = np.select([lmc_sep < 8], ['LMC'], default=xlocal)
+    xlocal = np.select([smc_sep < 5], ['SMC'], default=xlocal)
+    drp_all['Survey'] = xlocal
+
+    near = np.select([de < dw], ['SKY_EAST'], default='SKY_WEST')
+    far = np.select([de >= dw], ['SKY_EAST'], default='SKY_WEST')
+    drp_all['Near'] = near
+    drp_all['Far'] = far
+    drp_all['Redshift'] = np.select(
+        [drp_all['Survey'] == 'LMC', drp_all['Survey'] == 'SMC'],
+        [262., 146.], default=0.0)
+    return drp_all
+
+
+def read_drpall(drp_ver='1.2.0'):
+    '''
+    Read the drpall FITS file and return an augmented metadata table.
+
+    Looks for the file locally first, then falls back to the Utah path.
+
+    Parameters:
+        drp_ver (str): DRP version string (default '1.2.0').
+
+    Returns:
+        astropy.table.Table: drpall table with survey classification
+        columns added, or an empty list if the file cannot be found
+        or read.
+    '''
+    DRPFILE = 'drpall-%s.fits' % drp_ver
+    if os.path.isfile(DRPFILE):
+        xfile = DRPFILE
+    else:
+        BASEDIR = '/uufs/chpc.utah.edu/common/home/sdss51/sdsswork/lvm/spectro/redux/%s/' % drp_ver
+        xfile = '%s/%s' % (BASEDIR, DRPFILE)
+        if not os.path.isfile(xfile):
+            print('Error: Could not locate: %s' % xfile)
+            return []
+
+    print('Opening: %s' % xfile)
+    try:
+        drpall = fits.open(xfile)
+    except Exception:
+        print('Error: Located but could not read: %s' % xfile)
+        return []
+
+    drp_tab = Table(drpall[1].data)
+    drp_tab = augment_drp_all(drp_tab)
+    return drp_tab
+
+
+def select(ztab, exp_start=4000, exp_stop=8000, delta=5, exp_min=900.):
+    '''
+    Select every Nth exposure between exp_start and exp_stop.
+
+    Parameters:
+        ztab (astropy.table.Table): drpall table.
+        exp_start (int): First exposure number to include.
+        exp_stop (int): Last exposure number to include.
+        delta (int): Step size; selects every Nth row.
+        exp_min (float): Minimum exposure time in seconds.
+
+    Returns:
+        astropy.table.Table: Filtered table.
+    '''
+    xtab = ztab[ztab['expnum'] >= exp_start]
+    xtab = xtab[xtab['expnum'] <= exp_stop]
+    if exp_min > 0:
+        xtab = xtab[xtab['exptime'] >= exp_min]
+    if delta > 1:
+        xtab = xtab[::delta]
+    return xtab
+
+
+XTOP = '/uufs/chpc.utah.edu/common/home/sdss51/'
+XRAINBOW = '/Users/long/Projects/lvm_data/sas'
+XMUSKIE = '/home/long/Projects/lvm_data/sas'
+
+
+def find_top():
+    '''
+    Determine the top-level data directory for the current machine.
+
+    Returns:
+        str: Path to the top-level data directory, or an empty string
+        if the location cannot be determined.
+    '''
+    if os.path.isdir(XTOP):
+        loc = 'Utah'
+        topdir = XTOP
+    elif os.path.isdir(XRAINBOW):
+        loc = 'Rainbow'
+        topdir = XRAINBOW
+    elif os.path.isdir(XMUSKIE):
+        loc = 'Muskie'
+        topdir = XMUSKIE
+    else:
+        print('Error: I do not know where I am: %s' % os.getcwd())
+        return ''
+
+    print('We are on: %s' % loc)
+    return topdir
+
+
+def get_spec(xtab, spectrograph_id):
+    '''
+    Select good science fibers for a given spectrograph from a SLITMAP table.
+
+    Filters to rows where telescope == 'Sci', fibstatus == 0, and
+    spectrographid == spectrograph_id.
+
+    Parameters:
+        xtab (astropy.table.Table): SLITMAP table from an SFrame file.
+        spectrograph_id (int): Spectrograph identifier (1, 2, or 3).
+
+    Returns:
+        astropy.table.Table: Filtered table of matching fibers.
+    '''
+    good = xtab[xtab['telescope'] == 'Sci']
+    good = good[good['fibstatus'] == 0]
+    good = good[good['spectrographid'] == spectrograph_id]
+    return good
+
+
+def get_all_spec_specs(filename, percentile=50):
+    '''
+    Compute percentile flux spectra for each spectrograph from one SFrame file.
+
+    Opens the SFrame FITS file and checks whether science fibers are
+    present for each of the three spectrographs (spectrographid 1, 2, 3).
+    If any spectrograph has no valid science fibers the function returns
+    None for all arrays together with a status dictionary that records
+    which spectrographs were found.
+
+    Parameters:
+        filename (str): Path to the SFrame FITS file.
+        percentile (int): Percentile to compute across fibers (default 50).
+
+    Returns:
+        tuple: (wav, flux1, flux2, flux3, status) where wav is the
+        wavelength array, flux1/flux2/flux3 are 1-D percentile spectra
+        for spectrographs 1/2/3, and status is a dict with keys 'SP1',
+        'SP2', 'SP3' set to True if fibers were found and False otherwise.
+        If the file cannot be opened, returns (None, None, None, None, None).
+        If any spectrograph is missing, returns (None, None, None, None, status).
+    '''
+    try:
+        x = fits.open(filename)
+    except Exception:
+        print('get_all_spec_specs: Could not open %s' % filename)
+        return None, None, None, None, None
+
+    xtab = Table(x['SLITMAP'].data)
+    wav = x['WAVE'].data
+
+    status = {'SP1': False, 'SP2': False, 'SP3': False}
+    fiber_sets = {}
+    for sp_id, key in zip([1, 2, 3], ['SP1', 'SP2', 'SP3']):
+        fibers = get_spec(xtab, sp_id)
+        if len(fibers) > 0:
+            status[key] = True
+            fiber_sets[sp_id] = fibers
+        else:
+            status[key] = False
+
+    if not all(status.values()):
+        x.close()
+        return None, None, None, None, status
+
+    flux_out = []
+    for sp_id in [1, 2, 3]:
+        fibers = fiber_sets[sp_id]
+        sp_flux = x['FLUX'].data[fibers['fiberid'] - 1]
+        sp_mask = x['MASK'].data[fibers['fiberid'] - 1]
+        sp_flux = np.ma.masked_array(sp_flux, sp_mask)
+
+        if percentile == 50:
+            flux_percentile = np.ma.median(sp_flux, axis=0)
+        else:
+            sp_flux = np.ma.filled(sp_flux, np.nan)
+            flux_percentile = np.nanpercentile(sp_flux, percentile, axis=0)
+
+        flux_out.append(flux_percentile)
+
+    x.close()
+    return wav, flux_out[0], flux_out[1], flux_out[2], status
+
+
+def make_spec_specs(xtab, data_dir, outfile='', percentile=50, file_type='CFrame'):
+    '''
+    Process multiple CFrame or SFrame files and write a FITS summary by spectrograph.
+
+    Iterates over the exposures in xtab, calling get_all_spec_specs for
+    each file that exists on disk.  Exposures for which not all three
+    spectrographs have valid science fibers are skipped and recorded in a
+    separate ASCII table written alongside the main output file.
+
+    The drpall location column records SFrame paths.  When file_type is
+    'CFrame' (the default), 'SFrame' is replaced with 'CFrame' in the path
+    before checking for the file.
+
+    The main FITS file contains extensions WAVE, FLUX1, FLUX2, FLUX3, and
+    drp_all.  FLUX1/FLUX2/FLUX3 are 2-D arrays (n_exposures x n_wavelengths)
+    containing the percentile spectrum for spectrographs 1, 2, and 3.
+
+    The skipped-exposure table is always written and contains one row per
+    rejected exposure with columns expnum, mjd, tileid, SP1, SP2, SP3
+    showing which spectrographs were present (True) or absent (False).
+
+    Parameters:
+        xtab (astropy.table.Table): drpall table of selected exposures.
+        data_dir (str): Top-level data directory prepended to the location
+            column of xtab to form full file paths.
+        outfile (str): Output filename root (default 'test_spec.fits').
+        percentile (int): Percentile to compute across fibers (default 50).
+        file_type (str): 'CFrame' (default) or 'SFrame'.
+
+    Returns:
+        None
+    '''
+    # Identify files that exist on disk
+    select_idx = []
+    xfiles = []
+    for i in range(len(xtab)):
+        xfile = '%s/%s' % (data_dir, xtab['location'][i])
+        if file_type == 'CFrame':
+            xfile = xfile.replace('SFrame', 'CFrame')
+        if os.path.isfile(xfile):
+            select_idx.append(i)
+            xfiles.append(xfile)
+    print('There are %d files to process' % len(select_idx))
+
+    if len(select_idx) == 0:
+        print('Warning: No files found to process. Check exposure range and data directory.')
+        return
+
+    xtab = xtab[select_idx]
+
+    xflux1 = []
+    xflux2 = []
+    xflux3 = []
+    wav = None
+    good_idx = []
+
+    skipped_expnum = []
+    skipped_mjd = []
+    skipped_tileid = []
+    skipped_sp1 = []
+    skipped_sp2 = []
+    skipped_sp3 = []
+
+    for i in range(len(xfiles)):
+        xwav, flux1, flux2, flux3, status = get_all_spec_specs(xfiles[i], percentile)
+
+        if xwav is None and status is None:
+            # File could not be opened — skip silently
+            continue
+
+        if flux1 is None:
+            # One or more spectrographs missing — record in skipped table
+            row = xtab[i]
+            skipped_expnum.append(int(row['expnum']))
+            skipped_mjd.append(int(row['mjd']))
+            skipped_tileid.append(int(row['tileid']))
+            skipped_sp1.append(status['SP1'])
+            skipped_sp2.append(status['SP2'])
+            skipped_sp3.append(status['SP3'])
+            print('  Skipped expnum %d: SP1=%s SP2=%s SP3=%s' % (
+                row['expnum'], status['SP1'], status['SP2'], status['SP3']))
+            continue
+
+        wav = xwav
+        xflux1.append(flux1)
+        xflux2.append(flux2)
+        xflux3.append(flux3)
+        good_idx.append(i)
+
+        if i % 10 == 0:
+            print('Finished %d of %d' % (i, len(xfiles)))
+
+    # Always write the skipped table
+    if outfile == '' or outfile == 'test_spec.fits':
+        skipped_file = 'test_spec.skipped.txt'
+    else:
+        skipped_file = outfile.replace('.fits', '') + '.skipped.txt'
+
+    skipped_tab = Table([skipped_expnum, skipped_mjd, skipped_tileid,
+                         skipped_sp1, skipped_sp2, skipped_sp3],
+                        names=['expnum', 'mjd', 'tileid', 'SP1', 'SP2', 'SP3'])
+    skipped_tab.write(skipped_file, format='ascii.fixed_width_two_line', overwrite=True)
+    print('Skipped exposure table written to %s (%d exposures)' % (skipped_file, len(skipped_tab)))
+
+    if wav is None or len(xflux1) == 0:
+        print('Warning: No valid data extracted from any files.')
+        return
+
+    wav = np.array(wav)
+    xflux1 = np.array(xflux1)
+    xflux2 = np.array(xflux2)
+    xflux3 = np.array(xflux3)
+
+    good_tab = xtab[good_idx]
+
+    print('SP1 shape: %s  SP2 shape: %s  SP3 shape: %s' % (
+        xflux1.shape, xflux2.shape, xflux3.shape))
+
+    # Build WCS for spectral axis
+    wcs = WCS(naxis=2)
+    wcs.wcs.crpix = [1, 1]
+    wcs.wcs.crval = [wav[0], 0]
+    wcs.wcs.cdelt = [0.5, 1]
+    wcs.wcs.ctype = ['WAVE', 'LINE']
+
+    hdu1 = fits.PrimaryHDU(data=None)
+    hdu1.header['Title'] = '%s_Spec_Summary' % file_type
+    hdu1.header['PERCENT'] = (percentile, 'Percentile used for flux')
+    hdu1.header['SP1'] = ('spectrographid=1', 'Spectrograph 1 science fibers')
+    hdu1.header['SP2'] = ('spectrographid=2', 'Spectrograph 2 science fibers')
+    hdu1.header['SP3'] = ('spectrographid=3', 'Spectrograph 3 science fibers')
+
+    hdu2 = fits.ImageHDU(data=wav, name='WAVE')
+    hdu3 = fits.ImageHDU(data=xflux1, name='FLUX1')
+    hdu4 = fits.ImageHDU(data=xflux2, name='FLUX2')
+    hdu5 = fits.ImageHDU(data=xflux3, name='FLUX3')
+    hdu6 = fits.BinTableHDU(good_tab, name='drp_all')
+
+    hdu3.header.update(wcs.to_header())
+    hdu4.header.update(wcs.to_header())
+    hdu5.header.update(wcs.to_header())
+
+    hdul = fits.HDUList([hdu1, hdu2, hdu3, hdu4, hdu5, hdu6])
+
+    if outfile == '':
+        outfile = 'test_spec.fits'
+    else:
+        if not outfile.endswith('.fits'):
+            outfile = outfile + '.fits'
+
+    hdul.writeto(outfile, overwrite=True)
+    print('Wrote results to %s (%d exposures)' % (outfile, len(good_tab)))
+
+
+def doit(exp_start=4000, exp_stop=8000, delta=5, exp_min=900., out_name='',
+         drp_ver='1.2.0', percentile=50, file_type='CFrame'):
+    '''
+    Top-level driver: read drpall, select exposures, compute spectrograph spectra.
+
+    Parameters:
+        exp_start (int): First exposure number to process.
+        exp_stop (int): Last exposure number to process.
+        delta (int): Process every Nth exposure.
+        exp_min (float): Minimum exposure time in seconds.
+        out_name (str): Output file root name.
+        drp_ver (str): DRP version string.
+        percentile (int): Percentile to compute across fibers.
+        file_type (str): 'CFrame' (default) or 'SFrame'.
+
+    Returns:
+        None
+    '''
+    xtop = find_top()
+    xtab = read_drpall(drp_ver)
+    if len(xtab) == 0:
+        return
+    ztab = select(xtab, exp_start, exp_stop, delta, exp_min)
+
+    if out_name == '':
+        out_name = 'XSpec_%s_%s_%d_%d_%d_%d.fits' % (file_type, drp_ver, exp_start, exp_stop, delta, percentile)
+
+    make_spec_specs(ztab, xtop, outfile=out_name, percentile=percentile, file_type=file_type)
+
+
+def steer(argv):
+    '''
+    Parse command line arguments and run the spectrograph summary.
+
+    Parameters:
+        argv (list): Command line argument list (typically sys.argv).
+
+    Returns:
+        None
+    '''
+    exp_start = -1
+    exp_stop = -1
+    delta = -1
+    exp_min = 900
+    percent = 50
+    out_name = ''
+    ver = '1.2.0'
+    file_type = 'CFrame'
+
+    i = 1
+    while i < len(argv):
+        if argv[i][:2] == '-h':
+            print(__doc__)
+            return
+        elif argv[i] == '-sf':
+            file_type = 'SFrame'
+        elif argv[i] == '-emin':
+            i += 1
+            exp_min = int(argv[i])
+        elif argv[i] == '-out':
+            i += 1
+            out_name = argv[i]
+        elif argv[i] == '-ver':
+            i += 1
+            ver = argv[i]
+        elif argv[i][:5] == '-perc':
+            i += 1
+            percent = eval(argv[i])
+        elif argv[i][0] == '-':
+            print('Unknown option: %s' % argv[i])
+            return
+        elif exp_start < 0:
+            exp_start = int(argv[i])
+        elif exp_stop < 0:
+            exp_stop = int(argv[i])
+        elif delta < 0:
+            delta = int(argv[i])
+        i += 1
+
+    if exp_start < 0 or exp_stop < 0:
+        print('Usage: SummarizeSpec.py [-sf] [-ver drp_ver] [-percent 50] [-emin 900] [-out name] exp_start exp_stop delta')
+        return
+
+    if delta < 0:
+        delta = 1
+
+    doit(exp_start, exp_stop, delta, exp_min, out_name, drp_ver=ver, percentile=percent,
+         file_type=file_type)
+
+
+# Next lines permit one to run the routine from the command line
+if __name__ == '__main__':
+    if len(sys.argv) > 1:
+        steer(sys.argv)
+    else:
+        print(__doc__)


### PR DESCRIPTION
Adds SummarizeSpec.py, which computes per-spectrograph percentile spectra from CFrame (default) or SFrame files for science fibers only.  Exposures missing any of the three spectrographs are skipped and logged to a companion ASCII table.  Adds full Sphinx documentation in summarize.rst and api/SummarizeSpec/index.rst.  Fixes RST indentation warnings in api/find_obs/index.rst.  Rewrites Readme.md with a Quick Start installation section and a workflow-oriented overview, replacing the outdated per-script list, and corrects spelling throughout.